### PR TITLE
Add support for 1064nm depolarization channel, make all depol. channels optional

### DIFF
--- a/pollyxt_pipelines/enums.py
+++ b/pollyxt_pipelines/enums.py
@@ -1,0 +1,34 @@
+from enum import IntEnum
+
+
+class Wavelength(IntEnum):
+    """Laser wavelength"""
+
+    NM_355 = 355
+    NM_532 = 532
+    NM_1064 = 1064
+
+
+class Atmosphere(IntEnum):
+    """
+    Which atmosphere to use to processing. These are the possible values for `molecular_calc`.
+    """
+
+    AUTOMATIC = 0
+    RADIOSONDE = 1
+    CLOUDNET = 2
+    STANDARD_ATMOSPHERE = 4
+
+    @staticmethod
+    def from_string(x: str):
+        x = x.lower().strip()
+        if x == "automatic":
+            return Atmosphere.AUTOMATIC
+        if x == "radiosonde":
+            return Atmosphere.RADIOSONDE
+        if x == "cloudnet":
+            return Atmosphere.CLOUDNET
+        if x == "standard":
+            return Atmosphere.STANDARD_ATMOSPHERE
+
+        raise ValueError(f"Unknown atmosphere {x}")


### PR DESCRIPTION
This pull requests adds support for the 1064nm depolarization channel. In addition, all depol. channels are made optional. If any of the required parameters for a depol. channel are missing, that channel is automatically skipped when generating depolarization files.

Closes #26.