### PR TITLE
Add support for channel_string_IDs

### DIFF
--- a/pollyxt_pipelines/locations/__init__.py
+++ b/pollyxt_pipelines/locations/__init__.py
@@ -7,9 +7,9 @@ the .ini files are included with the software but custom locations can be define
 
 import io
 import sys
+import re
 from configparser import ConfigParser, SectionProxy
 from importlib.resources import read_text
-from datetime import time, timezone
 from typing import Dict, List, NamedTuple, Union, Optional
 
 from rich.markdown import Markdown
@@ -18,7 +18,7 @@ from rich.table import Table
 from pollyxt_pipelines import config
 from pollyxt_pipelines.enums import Wavelength
 from pollyxt_pipelines.console import console
-from pollyxt_pipelines.utils import ints_to_csv
+from pollyxt_pipelines.utils import ints_to_csv, parse_into_string_or_integer_list
 
 
 class Location(NamedTuple):
@@ -65,7 +65,7 @@ class Location(NamedTuple):
     depol_calibration_zero_state: int
     """Value of `depol_cal_angle` when there is *no* calibration taking place"""
 
-    channel_id: List[int]
+    channel_id: Union[List[int], List[str]]
     """Mapping of PollyXT Channels to SCC Channels
     Comma-separated list. The order of the list is the order of the channels in the
     PollyXT netCDF file.
@@ -104,36 +104,36 @@ class Location(NamedTuple):
     cross_channel_1064_nm_idx: Optional[int]
     """Index in Polly netCDF file for the cross channel (1064nm)"""
 
-    calibration_355nm_total_channel_ids: List[int]
+    calibration_355nm_total_channel_ids: Union[List[int], List[str]]
     """
     Calibration channel SCC IDs for 355nm. Comma separated list. First value must be the
     +45° channel, second value must be the -45° channel.
     """
 
-    calibration_355nm_cross_channel_ids: List[int]
+    calibration_355nm_cross_channel_ids: Union[List[int], List[str]]
     """
     Calibration channel SCC IDs for 355nm. Comma separated list. First value must be the
     +45° channel, second value must be the -45° channel.
     """
 
-    calibration_532nm_total_channel_ids: List[int]
+    calibration_532nm_total_channel_ids: Union[List[int], List[str]]
     """
     Calibration channel SCC IDs for 532nm. Comma separated list. First value must be the
     +45° channel, second value must be the -45° channel.
     """
 
-    calibration_532nm_cross_channel_ids: List[int]
+    calibration_532nm_cross_channel_ids: Union[List[int], List[str]]
     """
     Calibration channel SCC IDs for 532nm. Comma separated list. First value must be the
     +45° channel, second value must be the -45° channel.
     """
-    calibration_1064nm_total_channel_ids: List[int]
+    calibration_1064nm_total_channel_ids: Union[List[int], List[str]]
     """
     Calibration channel SCC IDs for 1064nm. Comma separated list. First value must be the
     +45° channel, second value must be the -45° channel.
     """
 
-    calibration_1064nm_cross_channel_ids: List[int]
+    calibration_1064nm_cross_channel_ids: Union[List[int], List[str]]
     """
     Calibration channel SCC IDs for 1064nm. Comma separated list. First value must be the
     +45° channel, second value must be the -45° channel.
@@ -197,43 +197,33 @@ def location_from_section(name: str, section: SectionProxy) -> Location:
     Create a Location from a ConfigParser Section (SectionProxy)
     """
 
-    channel_id = [int(x.strip()) for x in section.get("channel_id").split(",")]
+    channel_id = parse_into_string_or_integer_list(section.get("channel_id"))
     background_low = [int(x.strip()) for x in section.get("background_low").split(",")]
     background_high = [
         int(x.strip()) for x in section.get("background_high").split(",")
     ]
     lr_input = [int(x.strip()) for x in section.get("lr_input").split(",")]
 
-    calibration_355nm_total_channel_ids = [
-        int(x.strip())
-        for x in section.get("calibration_355nm_total_channel_ids", "").split(",")
-        if x.strip()
-    ]
-    calibration_355nm_cross_channel_ids = [
-        int(x.strip())
-        for x in section.get("calibration_355nm_cross_channel_ids", "").split(",")
-        if x.strip()
-    ]
-    calibration_532nm_total_channel_ids = [
-        int(x.strip())
-        for x in section.get("calibration_532nm_total_channel_ids", "").split(",")
-        if x.strip()
-    ]
-    calibration_532nm_cross_channel_ids = [
-        int(x.strip())
-        for x in section.get("calibration_532nm_cross_channel_ids", "").split(",")
-        if x.strip()
-    ]
-    calibration_1064nm_total_channel_ids = [
-        int(x.strip())
-        for x in section.get("calibration_1064nm_total_channel_ids", "").split(",")
-        if x.strip()
-    ]
-    calibration_1064nm_cross_channel_ids = [
-        int(x.strip())
-        for x in section.get("calibration_1064nm_cross_channel_ids", "").split(",")
-        if x.strip()
-    ]
+    calibration_355nm_total_channel_ids = parse_into_string_or_integer_list(
+        section.get("calibration_355nm_total_channel_ids")
+    )
+    calibration_355nm_cross_channel_ids = parse_into_string_or_integer_list(
+        section.get("calibration_355nm_cross_channel_ids")
+    )
+
+    calibration_532nm_total_channel_ids = parse_into_string_or_integer_list(
+        section.get("calibration_532nm_total_channel_ids")
+    )
+    calibration_532nm_cross_channel_ids = parse_into_string_or_integer_list(
+        section.get("calibration_532nm_cross_channel_ids")
+    )
+
+    calibration_1064nm_total_channel_ids = parse_into_string_or_integer_list(
+        section.get("calibration_1064nm_total_channel_ids")
+    )
+    calibration_1064nm_cross_channel_ids = parse_into_string_or_integer_list(
+        section.get("calibration_1064nm_cross_channel_ids")
+    )
 
     return Location(
         name=name,

--- a/pollyxt_pipelines/locations/locations.ini
+++ b/pollyxt_pipelines/locations/locations.ini
@@ -7,7 +7,7 @@ daytime_configuration = 437
 nighttime_configuration = 438
 calibration_configuration_355nm = 461
 calibration_configuration_532nm = 462
-channel_id = 493, 500, 497, 499, 494, 496, 498, 495, 501, 941, 940, 502
+channel_id = no000, no007, no004, no006, no001, no003, no005, no002, no008, no009, no010, no011
 background_low = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 background_high = 249, 249, 249, 249, 249, 249, 249, 249, 249, 249, 249, 249
 lr_input = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
@@ -18,14 +18,14 @@ total_channel_355_nm_idx = 0
 cross_channel_355_nm_idx = 1
 total_channel_532_nm_idx = 4
 cross_channel_532_nm_idx = 5
-calibration_355nm_total_channel_ids = 1266, 1268
-calibration_355nm_cross_channel_ids = 1236, 1267
-calibration_532nm_total_channel_ids = 1270, 1272
-calibration_532nm_cross_channel_ids = 1269, 1271
+calibration_355nm_total_channel_ids = no0024, no0026
+calibration_355nm_cross_channel_ids = no0014, no0025
+calibration_532nm_total_channel_ids = no0028, no0030
+calibration_532nm_cross_channel_ids = no0027, no0029
 profile_name = ANTIKYTHERA
 sounding_provider = noa_wrf
-sunrise_time=+69
-sunset_time=-15
+sunrise_time=04:00
+sunset_time=18:00
 
 
 [Finokalia]

--- a/pollyxt_pipelines/polly_to_scc/scc_netcdf.py
+++ b/pollyxt_pipelines/polly_to_scc/scc_netcdf.py
@@ -8,7 +8,7 @@ from typing import Tuple
 import re
 
 import numpy as np
-from netCDF4 import Dataset, stringtochar
+from netCDF4 import Dataset
 from astral import LocationInfo
 from astral.sun import sunrise, sunset
 
@@ -127,13 +127,12 @@ def create_scc_netcdf(
         channel_id[:] = np.array(location.channel_id)
     else:
         str_len = np.max([len(x) for x in location.channel_id])
-        nc.createDimension("channel_string_length", str_len)
         channel_id = nc.createVariable(
             "channel_string_ID",
-            "S1",
-            dimensions=("channels", "channel_string_length"),
+            f"S{str_len}",
+            dimensions=("channels"),
         )
-        channel_id[:] = stringtochar(np.array(location.channel_id, f"S{str_len}"))
+        channel_id[:] = np.array(location.channel_id, f"S{str_len}")
 
     id_timescale = nc.createVariable(
         "id_timescale", "i4", dimensions=("channels"), zlib=True
@@ -322,13 +321,12 @@ def create_scc_calibration_netcdf(
         channel_id[:] = np.array(channel_ids)
     else:
         str_len = np.max([len(x) for x in channel_ids])
-        nc.createDimension("channel_string_length", str_len)
         channel_id = nc.createVariable(
             "channel_string_ID",
-            "S1",
-            dimensions=("channels", "channel_string_length"),
+            f"S{str_len}",
+            dimensions=("channels"),
         )
-        channel_id[:] = stringtochar(np.array(channel_ids, f"S{str_len}"))
+        channel_id[:] = np.array(channel_ids)
     id_timescale = nc.createVariable(
         "id_timescale", "i4", dimensions=("channels"), zlib=True
     )

--- a/pollyxt_pipelines/scc_access/__init__.py
+++ b/pollyxt_pipelines/scc_access/__init__.py
@@ -343,7 +343,9 @@ class SCC:
 
         data_input_field = response_body.find("input", id="id_data")
         if data_input_field is not None:
-            data_text = data_input_field.parent.find("p").text.strip().replace("\n", " ")
+            data_text = (
+                data_input_field.parent.find("p").text.strip().replace("\n", " ")
+            )
             if "Error:" in data_text:
                 raise exceptions.SCCError(data_text)
 

--- a/pollyxt_pipelines/utils.py
+++ b/pollyxt_pipelines/utils.py
@@ -1,6 +1,6 @@
 """Various helper functions that fit nowhere"""
 
-from typing import List
+from typing import List, Union, Optional
 from datetime import datetime, timedelta
 import re
 
@@ -111,3 +111,22 @@ def date_option_to_datetime(today: datetime, string: str) -> datetime:
             return today.replace(minute=minute)
 
     raise ValueError("`string` is neither in XX:MM, HH:MM nor YYYY-mm-DD HH:MM format!")
+
+
+def parse_into_string_or_integer_list(
+    text_values: Optional[str],
+) -> Optional[Union[List[int], List[str]]]:
+    """
+    Parses comma-seperated values into a list of either integers or string.
+    For the resulting list to be an integer one, all values must be integers (0-9)
+    If input is none, returns none.
+    """
+
+    if text_values is None:
+        return None
+
+    values = [x.strip() for x in text_values.split(",")]
+    if all([re.match(r"^\d+$", x) for x in values]):
+        return [int(x) for x in values]
+    else:
+        return values


### PR DESCRIPTION
SCC added a new (optional) field called `channel_string_IDs` that lets you use the user-defined channel strings instead of the system integers. This is more portable, since you can always name a channel to match the one you want instead of relying on auto-generated numbers.

This pull requests adds support for this new feature but it is currently not working correctly, as SCC crashes on file upload.